### PR TITLE
add logging for unsupported version

### DIFF
--- a/rep/error_test.go
+++ b/rep/error_test.go
@@ -2,20 +2,31 @@ package rep
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 )
 
-func TestErrUnsupportedRepVersion_Metadata(t *testing.T) {
-	bb := 12345
-	err := fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
+func TestUnsupportedRepVersionError_ErrorsIs(t *testing.T) {
+	err := &UnsupportedRepVersionError{Build: 12345}
 
 	if !errors.Is(err, ErrUnsupportedRepVersion) {
 		t.Errorf("errors.Is(err, ErrUnsupportedRepVersion) = false, want true")
 	}
+}
 
-	expectedMsg := "Unsupported replay version, metadata: {\"build\": 12345}"
-	if err.Error() != expectedMsg {
-		t.Errorf("err.Error() = %q, want %q", err.Error(), expectedMsg)
+func TestUnsupportedRepVersionError_MessageWithoutClosest(t *testing.T) {
+	err := &UnsupportedRepVersionError{Build: 12345}
+
+	expected := "Unsupported replay version, metadata: {\"build\": 12345}"
+	if err.Error() != expected {
+		t.Errorf("err.Error() = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestUnsupportedRepVersionError_MessageWithClosest(t *testing.T) {
+	err := &UnsupportedRepVersionError{Build: 12345, Closest: 96702}
+
+	expected := "Unsupported replay version, metadata: {\"build\": 12345, \"closest\": 96702}"
+	if err.Error() != expected {
+		t.Errorf("err.Error() = %q, want %q", err.Error(), expected)
 	}
 }

--- a/rep/error_test.go
+++ b/rep/error_test.go
@@ -1,0 +1,21 @@
+package rep
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrUnsupportedRepVersion_Metadata(t *testing.T) {
+	bb := 12345
+	err := fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
+
+	if !errors.Is(err, ErrUnsupportedRepVersion) {
+		t.Errorf("errors.Is(err, ErrUnsupportedRepVersion) = false, want true")
+	}
+
+	expectedMsg := "Unsupported replay version, metadata: {\"build\": 12345}"
+	if err.Error() != expectedMsg {
+		t.Errorf("err.Error() = %q, want %q", err.Error(), expectedMsg)
+	}
+}

--- a/rep/rep.go
+++ b/rep/rep.go
@@ -27,12 +27,35 @@ var (
 	ErrInvalidRepFile = errors.New("Invalid SC2Replay file")
 
 	// ErrUnsupportedRepVersion means the replay file is valid but its version is not supported.
+	// Errors wrapping ErrUnsupportedRepVersion (e.g. UnsupportedRepVersionError) are returned by
+	// the parser functions; use errors.Is to check for this sentinel value.
 	ErrUnsupportedRepVersion = errors.New("Unsupported replay version")
 
 	// ErrDecoding means decoding the replay file failed,
 	// Most likely because replay file is invalid, but also might be due to an implementation bug
 	ErrDecoding = errors.New("Decoding error")
 )
+
+// UnsupportedRepVersionError is returned when a replay file's version is not supported.
+// It wraps ErrUnsupportedRepVersion and carries the replay's base build number.
+// When build coercion was attempted, Closest holds the nearest supported base build
+// (otherwise Closest is 0). Use errors.Is(err, ErrUnsupportedRepVersion) to test for
+// this condition without coupling to the concrete type.
+type UnsupportedRepVersionError struct {
+	Build   int // The base build of the unsupported replay
+	Closest int // The closest supported base build (0 if coercion was not attempted)
+}
+
+func (e *UnsupportedRepVersionError) Error() string {
+	if e.Closest != 0 {
+		return fmt.Sprintf("%s, metadata: {\"build\": %d, \"closest\": %d}", ErrUnsupportedRepVersion.Error(), e.Build, e.Closest)
+	}
+	return fmt.Sprintf("%s, metadata: {\"build\": %d}", ErrUnsupportedRepVersion.Error(), e.Build)
+}
+
+func (e *UnsupportedRepVersionError) Unwrap() error {
+	return ErrUnsupportedRepVersion
+}
 
 // Rep describes a replay.
 type Rep struct {
@@ -62,7 +85,9 @@ type Rep struct {
 //
 // ErrInvalidRepFile is returned if the specified name does not denote a valid SC2Replay file.
 //
-// ErrUnsupportedRepVersion is returned if the file exists and is a valid SC2Replay file but its version is not supported.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the file
+// exists and is a valid SC2Replay file but its version is not supported.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the replay file is invalid, but also might be due to an implementation bug.
 func NewFromFile(name string) (*Rep, error) {
@@ -76,7 +101,9 @@ func NewFromFile(name string) (*Rep, error) {
 //
 // ErrInvalidRepFile is returned if the specified name does not denote a valid SC2Replay file.
 //
-// ErrUnsupportedRepVersion is returned if the file exists and is a valid SC2Replay file but its version is not supported.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the file
+// exists and is a valid SC2Replay file but its version is not supported.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the replay file is invalid, but also might be due to an implementation bug.
 func NewFromFileEvents(name string, game, message, tracker bool) (*Rep, error) {
@@ -93,7 +120,9 @@ func NewFromFileEvents(name string, game, message, tracker bool) (*Rep, error) {
 //
 // ErrInvalidRepFile is returned if the input is not a valid SC2Replay file content.
 //
-// ErrUnsupportedRepVersion is returned if the input is a valid SC2Replay file but its version is not supported.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the input
+// is a valid SC2Replay file but its version is not supported.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the input is invalid, but also might be due to an implementation bug.
 func New(input io.ReadSeeker) (*Rep, error) {
@@ -107,7 +136,9 @@ func New(input io.ReadSeeker) (*Rep, error) {
 //
 // ErrInvalidRepFile is returned if the input is not a valid SC2Replay file content.
 //
-// ErrUnsupportedRepVersion is returned if the input is a valid SC2Replay file but its version is not supported.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the input
+// is a valid SC2Replay file but its version is not supported.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the input is invalid, but also might be due to an implementation bug.
 func NewEvents(input io.ReadSeeker, game, message, tracker bool) (*Rep, error) {
@@ -153,7 +184,7 @@ func newRep(m *mpq.MPQ, game, message, tracker bool) (parsedRep *Rep, errRes err
 	bb := rep.Header.BaseBuild()
 	p := s2prot.GetProtocol(int(bb))
 	if p == nil {
-		return nil, fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
+		return nil, &UnsupportedRepVersionError{Build: int(bb)}
 	}
 	rep.protocol = p
 
@@ -266,7 +297,9 @@ func findClosestSupportedBaseBuild(baseBuild int) (int, bool) {
 //
 // ErrInvalidRepFile is returned if the input is not a valid SC2Replay file content.
 //
-// ErrUnsupportedRepVersion is returned if the input is a valid SC2Replay file but no supported protocol exists to coerce to.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the input
+// is a valid SC2Replay file but no supported protocol exists to coerce to.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the input is invalid, but also might be due to an implementation bug.
 func NewEventsWithBuildCoercion(input io.ReadSeeker, game, message, tracker bool) (*Rep, int, error) {
@@ -284,7 +317,9 @@ func NewEventsWithBuildCoercion(input io.ReadSeeker, game, message, tracker bool
 //
 // ErrInvalidRepFile is returned if the specified name does not denote a valid SC2Replay file.
 //
-// ErrUnsupportedRepVersion is returned if the file exists and is a valid SC2Replay file but no supported protocol exists to coerce to.
+// ErrUnsupportedRepVersion is returned (wrapped in UnsupportedRepVersionError) if the file
+// exists and is a valid SC2Replay file but no supported protocol exists to coerce to.
+// Use errors.Is(err, ErrUnsupportedRepVersion) to test for this condition.
 //
 // ErrDecoding is returned if decoding the replay fails. This is most likely because the replay file is invalid, but also might be due to an implementation bug.
 func NewFromFileEventsWithBuildCoercion(name string, game, message, tracker bool) (*Rep, int, error) {
@@ -335,12 +370,12 @@ func newRepWithBuildCoercion(m *mpq.MPQ, game, message, tracker bool) (parsedRep
 		// find closest supported build
 		closest, ok := findClosestSupportedBaseBuild(bb)
 		if !ok {
-			return nil, 0, fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
+			return nil, 0, &UnsupportedRepVersionError{Build: bb}
 		}
 		p = s2prot.GetProtocol(closest)
 		if p == nil {
 			// Should not happen but guard anyway
-			return nil, 0, fmt.Errorf("%w, metadata: {\"build\": %d, \"closest\": %d}", ErrUnsupportedRepVersion, bb, closest)
+			return nil, 0, &UnsupportedRepVersionError{Build: bb, Closest: closest}
 		}
 		coercedTo = closest
 	}

--- a/rep/rep.go
+++ b/rep/rep.go
@@ -9,6 +9,7 @@ package rep
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/stego-research/mpq"
@@ -152,7 +153,7 @@ func newRep(m *mpq.MPQ, game, message, tracker bool) (parsedRep *Rep, errRes err
 	bb := rep.Header.BaseBuild()
 	p := s2prot.GetProtocol(int(bb))
 	if p == nil {
-		return nil, ErrUnsupportedRepVersion
+		return nil, fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
 	}
 	rep.protocol = p
 
@@ -334,12 +335,12 @@ func newRepWithBuildCoercion(m *mpq.MPQ, game, message, tracker bool) (parsedRep
 		// find closest supported build
 		closest, ok := findClosestSupportedBaseBuild(bb)
 		if !ok {
-			return nil, 0, ErrUnsupportedRepVersion
+			return nil, 0, fmt.Errorf("%w, metadata: {\"build\": %d}", ErrUnsupportedRepVersion, bb)
 		}
 		p = s2prot.GetProtocol(closest)
 		if p == nil {
 			// Should not happen but guard anyway
-			return nil, 0, ErrUnsupportedRepVersion
+			return nil, 0, fmt.Errorf("%w, metadata: {\"build\": %d, \"closest\": %d}", ErrUnsupportedRepVersion, bb, closest)
 		}
 		coercedTo = closest
 	}


### PR DESCRIPTION
This pull request improves error handling for unsupported replay versions by including additional metadata in error messages, making debugging easier. It also adds a unit test to verify the new error message format.

**Error handling improvements:**

* Updated all returns of `ErrUnsupportedRepVersion` in `rep/rep.go` to wrap the error with additional metadata, such as the `build` number and, where applicable, the `closest` supported build. This provides more context when an unsupported replay version is encountered. [[1]](diffhunk://#diff-29c974b8d1da19362bb57ebcb86ad5e50792e035f81b606cc95d58e604ea02b2L155-R156) [[2]](diffhunk://#diff-29c974b8d1da19362bb57ebcb86ad5e50792e035f81b606cc95d58e604ea02b2L337-R343)
* Imported the `fmt` package in `rep/rep.go` to support error wrapping with formatted messages.

**Testing:**

* Added a new unit test `TestErrUnsupportedRepVersion_Metadata` in `error_test.go` to verify that the error message includes the expected metadata and that the error can still be identified using `errors.Is`.