### PR TITLE
Housekeeping & Reliability/Performance

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
       - name: Cache Go build
         uses: actions/cache@v4
         with:

--- a/audit_repro_test.go
+++ b/audit_repro_test.go
@@ -1,0 +1,78 @@
+package s2prot
+
+import (
+	"runtime"
+	"testing"
+)
+
+// These tests pin two decoder bugs reachable from a crafted replay:
+//
+//  1. Unbounded slice preallocation. s2pArr/s2pBitArr/s2pBlob size their
+//     make() directly from an attacker-controlled length with no check against
+//     the bytes that actually remain in the buffer, so a near-empty input can
+//     drive an arbitrarily large allocation (here 64 MiB from a 4-byte input;
+//     a larger declared length OOM-kills the process — a fatal runtime throw
+//     that the recover()s in decodeEvents/newRep/LoadS2ProtRepFromFileBytes
+//     cannot catch).
+//
+//  2. An off-by-one in the bit-packed choice decoder: `tag > len(fields)`
+//     should be `tag >= len(fields)` (the versioned decoder gets this right),
+//     so tag == len(fields) indexes one past the slice and panics.
+//
+// They assert the desired post-fix behavior so they double as regression tests.
+
+func allocDelta(fn func()) uint64 {
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+// TestArrayLengthBoundedByBuffer proves the array length is not validated
+// against the remaining input. The element type needs at least 8 bits each, so
+// a 4-byte buffer can hold at most 4 elements; a declared length of 4,000,000
+// must be rejected before make([]interface{}, length) (64 MiB).
+func TestArrayLengthBoundedByBuffer(t *testing.T) {
+	typeInfos := []typeInfo{
+		{s2pType: s2pArr, typeid: 1, bits: 0, offset64: 4_000_000}, // length comes entirely from offset64
+		{s2pType: s2pInt, bits: 8, offset64: 0},                    // element: 8-bit int
+	}
+	contents := make([]byte, 4)
+
+	const ceiling = 4 << 20 // 4 MiB; the unguarded alloc is ~64 MiB
+	delta := allocDelta(func() {
+		defer func() { _ = recover() }() // element decode will run off the 4-byte buffer
+		d := newBitPackedDec(contents, typeInfos)
+		d.instance(0)
+	})
+	if delta > ceiling {
+		t.Fatalf("array decode allocated %d bytes from a 4-byte input (> %d ceiling); "+
+			"length not bounded by remaining buffer", delta, ceiling)
+	}
+}
+
+// TestChoiceTagOffByOne pins the bit-packed choice bounds check. With one field
+// and a tag of 1 (== len(fields)), the decoder must treat the tag as invalid
+// and return nil rather than indexing fields[1].
+func TestChoiceTagOffByOne(t *testing.T) {
+	typeInfos := []typeInfo{
+		{s2pType: s2pChoice, bits: 0, offset64: 1, fields: []field{{name: "a", typeid: 1}}}, // tag = 1
+		{s2pType: s2pNull},
+	}
+	contents := make([]byte, 4)
+
+	var res interface{}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("choice decode panicked on out-of-range tag (off-by-one: tag > len should be >=): %v", r)
+			}
+		}()
+		d := newBitPackedDec(contents, typeInfos)
+		res = d.instance(0)
+	}()
+	if res != nil {
+		t.Fatalf("expected nil for out-of-range choice tag, got %v", res)
+	}
+}

--- a/audit_repro_test.go
+++ b/audit_repro_test.go
@@ -76,3 +76,80 @@ func TestChoiceTagOffByOne(t *testing.T) {
 		t.Fatalf("expected nil for out-of-range choice tag, got %v", res)
 	}
 }
+
+// putVarInt encodes v in the versioned decoder's varint format (7 data bits per
+// byte, LSB first, high bit = continue; the value's low bit is the sign).
+func putVarInt(v int64) []byte {
+	var u uint64
+	if v < 0 {
+		u = (uint64(-v) << 1) | 1
+	} else {
+		u = uint64(v) << 1
+	}
+	var out []byte
+	for {
+		b := byte(u & 0x7f)
+		if u >>= 7; u != 0 {
+			out = append(out, b|0x80)
+		} else {
+			out = append(out, b)
+			return out
+		}
+	}
+}
+
+// TestVersionedChoiceBadTagStaysInSync pins the PR #10 review fix: when a
+// versioned choice carries an out-of-range tag, the decoder must still skip the
+// choice's (self-describing) value, or every later field desyncs. The struct
+// here has a choice field (bad tag) followed by an int field; the int must still
+// decode correctly.
+func TestVersionedChoiceBadTagStaysInSync(t *testing.T) {
+	typeInfos := []typeInfo{
+		{s2pType: s2pStruct, fields: []field{{name: "c", typeid: 1, tag: 0}, {name: "x", typeid: 2, tag: 1}},
+			tagIndex: map[int]int{0: 0, 1: 1}},
+		{s2pType: s2pChoice, fields: []field{{name: "only", typeid: 2}}}, // valid tag is only 0
+		{s2pType: s2pInt},
+	}
+	var buf []byte
+	buf = append(buf, 0x05)             // struct field-type
+	buf = append(buf, putVarInt(2)...)  // field count = 2
+	buf = append(buf, putVarInt(0)...)  // field tag 0 (the choice)
+	buf = append(buf, 0x03)             // choice field-type
+	buf = append(buf, putVarInt(99)...) // out-of-range choice tag
+	buf = append(buf, 0x09)             // choice value: vint field-type
+	buf = append(buf, putVarInt(42)...) // choice value = 42 (must be skipped)
+	buf = append(buf, putVarInt(1)...)  // field tag 1 (the int)
+	buf = append(buf, 0x09)             // int field-type (vint)
+	buf = append(buf, putVarInt(7)...)  // int value = 7
+
+	d := newVersionedDec(buf, typeInfos)
+	s, ok := d.instance(0).(Struct)
+	if !ok {
+		t.Fatalf("expected a Struct, got %T", d.instance(0))
+	}
+	if s["x"] != int64(7) {
+		t.Fatalf("stream desynced: expected x=7 after a bad-tag choice, got x=%v", s["x"])
+	}
+	if s["c"] != nil {
+		t.Fatalf("expected nil for the out-of-range choice, got %v", s["c"])
+	}
+}
+
+// TestVersionedNegativeArrayLengthRejected pins the PR #10 review fix that a
+// negative versioned length aborts decoding (panic, recovered upstream) rather
+// than silently returning and leaving the payload unconsumed.
+func TestVersionedNegativeArrayLengthRejected(t *testing.T) {
+	typeInfos := []typeInfo{
+		{s2pType: s2pArr, typeid: 1},
+		{s2pType: s2pInt},
+	}
+	buf := []byte{0x00}                 // array field-type
+	buf = append(buf, putVarInt(-1)...) // negative length
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected a panic for negative array length, got none")
+		}
+	}()
+	newVersionedDec(buf, typeInfos).instance(0)
+}

--- a/bitpackedbuff.go
+++ b/bitpackedbuff.go
@@ -6,8 +6,44 @@ Implementation of a byte buffer whose content can be accessed/interpreted by bit
 
 package s2prot
 
+import "errors"
+
+// errInvalidLength is panicked (and recovered by the decode entry points) when a
+// type's declared length cannot be backed by the bytes remaining in the buffer.
+// Decoders previously sized make() directly from these attacker-controlled
+// lengths, so a tiny crafted input could declare a huge array/blob/bitarray and
+// drive a multi-GB allocation (a fatal OOM that recover() cannot catch).
+var errInvalidLength = errors.New("s2prot: declared length exceeds remaining buffer")
+
+// clampSliceCap bounds the initial capacity used when decoding an array of a
+// declared (untrusted) length. Elements are appended as they are decoded, so the
+// up-front allocation stays small no matter how large the declared length is.
+func clampSliceCap(n int64) int {
+	const max = 1024
+	if n < max {
+		return int(n)
+	}
+	return max
+}
+
 // Bit masks having as many ones at the lowest bits as the index.
 var bitMasks = [...]byte{0x00, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff}
+
+// bytesLeft reports the number of whole, unconsumed bytes in contents. It ignores
+// any bits still held in cache, so it never over-reports what remains.
+func (b *bitPackedBuff) bytesLeft() int {
+	if n := len(b.contents) - b.idx; n > 0 {
+		return n
+	}
+	return 0
+}
+
+// bitsLeft reports an upper bound on the number of bits still readable: the
+// cached bits plus the whole bytes remaining. Used to reject a declared length
+// that no valid input could satisfy before allocating from it.
+func (b *bitPackedBuff) bitsLeft() int {
+	return int(b.cacheBits) + b.bytesLeft()*8
+}
 
 // The wrapper around a []byte providing access by arbitrary number of bits.
 type bitPackedBuff struct {

--- a/bitpackeddec.go
+++ b/bitpackeddec.go
@@ -88,7 +88,10 @@ func (d *bitPackedDec) instance(typeid int) interface{} {
 		return s
 	case s2pChoice:
 		tag := int(readInt())
-		if tag > len(ti.fields) {
+		// Bounds: tag indexes ti.fields, so a valid tag is in [0, len). The
+		// original `tag > len(ti.fields)` was off by one (the versioned decoder
+		// uses >=), letting tag == len index one past the slice and panic.
+		if tag < 0 || tag >= len(ti.fields) {
 			return nil
 		}
 		f := ti.fields[tag]
@@ -98,14 +101,27 @@ func (d *bitPackedDec) instance(typeid int) interface{} {
 		return s
 	case s2pArr:
 		length := readInt()
-		arr := make([]interface{}, length)
-		for i := range arr {
-			arr[i] = d.instance(ti.typeid)
+		if length < 0 {
+			return nil
+		}
+		// Do not preallocate make([]interface{}, length) from the attacker-
+		// controlled length: a crafted input can declare a huge length and OOM-kill
+		// the process (a fatal runtime throw recover() cannot catch). Grow with
+		// append so memory tracks elements actually decoded; a length that outruns
+		// the buffer hits EOF (panic, recovered) after a bounded number of reads.
+		arr := make([]interface{}, 0, clampSliceCap(length))
+		for i := int64(0); i < length; i++ {
+			arr = append(arr, d.instance(ti.typeid))
 		}
 		return arr
 	case s2pBitArr:
 		// length may be > 64, so simple readBits() is not enough
 		length := int(readInt())
+		// length bits are read from the buffer; reject a length no input could back
+		// before sizing the (length+7)/8-byte buffer from it.
+		if length < 0 || length > b.bitsLeft() {
+			panic(errInvalidLength)
+		}
 		buf := make([]byte, (length+7)/8)    // Number of required bytes
 		copy(buf, b.readUnaligned(length/8)) // Number of whole bytes:
 		if remaining := byte(length % 8); remaining != 0 {
@@ -114,6 +130,10 @@ func (d *bitPackedDec) instance(typeid int) interface{} {
 		return BitArr{Count: length, Data: buf}
 	case s2pBlob:
 		length := readInt()
+		// length bytes are read aligned; reject before make([]byte, length).
+		if length < 0 || length > int64(b.bytesLeft()) {
+			panic(errInvalidLength)
+		}
 		return string(b.readAligned(int(length)))
 	case s2pOptional:
 		if b.readBits1() {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/stego-research/s2prot/v2
 
-go 1.25.1
+go 1.26.3
 
-require github.com/stego-research/mpq v1.6.0
+require github.com/stego-research/mpq v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/stego-research/mpq v1.6.0 h1:FAK24y7O7HE+NCU8Ru1heqsfDAjXY0/4szHcpDEm4nE=
-github.com/stego-research/mpq v1.6.0/go.mod h1:26y+/scKow22La7dHzIDf+0+ARtRPk56Zd4zBhSlh0I=
+github.com/stego-research/mpq v1.6.2 h1:Cts0uWX7KeVJug/7jRYpN0r76qvIEd5h/Adi6r7AIZQ=
+github.com/stego-research/mpq v1.6.2/go.mod h1:nDu4DoAs02EaNcWe7g8HFZZUTEoqQSoZ5yVI+ICleTQ=

--- a/protocol.go
+++ b/protocol.go
@@ -513,21 +513,17 @@ func (p *Protocol) decodeEvents(d decoder, evtidTypeid int, etypes []EventType, 
 				// number of fields
 				for n := int(readVarInt(vd.bitPackedBuff)); n > 0; n-- {
 					tag := int(readVarInt(vd.bitPackedBuff))
-					var fsel *field
-					for i := range deltaTI.fields {
-						if deltaTI.fields[i].tag == tag {
-							fsel = &deltaTI.fields[i]
-							break
-						}
-					}
-					if fsel == nil {
-						// Unknown field: skip its encoded value. (The previous
-						// vd.instance(tag) treated the field *tag* as a *typeid*,
-						// indexing the wrong type info and desyncing the stream.)
+					// Use the precomputed tag->index map (deltaTI is a struct here)
+					// rather than an O(n) scan per tag, matching the optimization in
+					// versionedDec.instance.
+					idx, ok := deltaTI.tagIndex[tag]
+					if !ok {
+						// Unknown field: skip its encoded value. (Treating the field
+						// tag as a typeid would index the wrong type info and desync.)
 						skipInstance(vd.bitPackedBuff)
 						continue
 					}
-					if v, ok := vd.instance(fsel.typeid).(int64); ok {
+					if v, ok := vd.instance(deltaTI.fields[idx].typeid).(int64); ok {
 						loop += v
 					}
 				}

--- a/protocol.go
+++ b/protocol.go
@@ -456,10 +456,13 @@ func (p *Protocol) decodeEvents(d decoder, evtidTypeid int, etypes []EventType, 
 				tag := int(deltaTI.offset64 + bp.readBits(byte(deltaTI.bits)))
 				if tag < len(deltaTI.fields) && tag >= 0 {
 					f := deltaTI.fields[tag]
-					if v, ok := bp.instance(f.typeid).(int64); ok {
+					// Decode the field value exactly once: a second bp.instance call
+					// would consume more of the buffer and desync every later event.
+					switch v := bp.instance(f.typeid).(type) {
+					case int64:
 						loop += v
-					} else if s, ok := bp.instance(f.typeid).(Struct); ok {
-						for _, iv := range s {
+					case Struct:
+						for _, iv := range v {
 							if n, ok := iv.(int64); ok {
 								loop += n
 							}
@@ -493,10 +496,12 @@ func (p *Protocol) decodeEvents(d decoder, evtidTypeid int, etypes []EventType, 
 				tag := int(readVarInt(vd.bitPackedBuff))
 				if tag < len(deltaTI.fields) && tag >= 0 {
 					f := deltaTI.fields[tag]
-					if v, ok := vd.instance(f.typeid).(int64); ok {
+					// Decode the field value exactly once (see bit-packed path above).
+					switch v := vd.instance(f.typeid).(type) {
+					case int64:
 						loop += v
-					} else if s, ok := vd.instance(f.typeid).(Struct); ok {
-						for _, iv := range s {
+					case Struct:
+						for _, iv := range v {
 							if n, ok := iv.(int64); ok {
 								loop += n
 							}
@@ -516,8 +521,10 @@ func (p *Protocol) decodeEvents(d decoder, evtidTypeid int, etypes []EventType, 
 						}
 					}
 					if fsel == nil {
-						// Unknown field; skip reading one instance generically
-						_ = vd.instance(tag) // best-effort
+						// Unknown field: skip its encoded value. (The previous
+						// vd.instance(tag) treated the field *tag* as a *typeid*,
+						// indexing the wrong type info and desyncing the stream.)
+						skipInstance(vd.bitPackedBuff)
 						continue
 					}
 					if v, ok := vd.instance(fsel.typeid).(int64); ok {

--- a/types.go
+++ b/types.go
@@ -62,6 +62,12 @@ type typeInfo struct {
 	// For struct, and also for choice
 	fields []field // List of fields (in case of struct)
 
+	// tagIndex maps a struct field's tag to its index in fields. Built once at
+	// parse time and shared read-only across all decodes, so the versioned struct
+	// decoder no longer rebuilds this map for every struct instance it decodes
+	// (a hot path for tracker events). Only populated for s2pStruct types.
+	tagIndex map[int]int
+
 	// For array, also used for optional
 	typeid int // Type id (index) of the elements of the array
 }
@@ -137,6 +143,11 @@ func parseTypeInfo(s string) typeInfo {
 		// Copy a trimmed version of this to type info:
 		ti.fields = make([]field, len(fields))
 		copy(ti.fields, fields)
+		// Precompute the tag->index map once (used by the versioned struct decoder).
+		ti.tagIndex = make(map[int]int, len(ti.fields))
+		for i := range ti.fields {
+			ti.tagIndex[ti.fields[i].tag] = i
+		}
 	case s2pChoice: // ('_choice',[(0,2),{0:('None',91),1:('TargetPoint',93),2:('TargetUnit',94),3:('Data',6)}]),  #95
 		// Parameters: offset and bits which will provide the index integer value to choose
 		// from the following field list

--- a/versioneddec.go
+++ b/versioneddec.go
@@ -52,11 +52,9 @@ func (d *versionedDec) instance(typeid int) interface{} {
 			s[name] = val
 		}
 		length := int(readVarInt(b))
-		// Build tag->index map once to avoid O(n) scans per field
-		tagIndex := make(map[int]int, len(ti.fields))
-		for i := range ti.fields {
-			tagIndex[ti.fields[i].tag] = i
-		}
+		// tag->index map is precomputed once per type at parse time (ti.tagIndex),
+		// so this struct decode does not rebuild it per instance.
+		tagIndex := ti.tagIndex
 		for i := 0; i < length; i++ {
 			tag := int(readVarInt(b))
 			idx, ok := tagIndex[tag]
@@ -100,7 +98,7 @@ func (d *versionedDec) instance(typeid int) interface{} {
 	case s2pChoice:
 		b.readBits8() // Field type (3)
 		tag := int(readVarInt(b))
-		if tag >= len(ti.fields) {
+		if tag < 0 || tag >= len(ti.fields) {
 			return nil
 		}
 		f := ti.fields[tag]
@@ -111,18 +109,31 @@ func (d *versionedDec) instance(typeid int) interface{} {
 	case s2pArr:
 		b.readBits8() // Field type (0)
 		length := readVarInt(b)
-		arr := make([]interface{}, length)
-		for i := range arr {
-			arr[i] = d.instance(ti.typeid)
+		if length < 0 {
+			return nil
+		}
+		// Grow with append instead of make([]interface{}, length): the length is
+		// attacker-controlled and preallocating from it can OOM-kill the process
+		// (a fatal throw recover() cannot catch). See bitPackedDec.instance.
+		arr := make([]interface{}, 0, clampSliceCap(length))
+		for i := int64(0); i < length; i++ {
+			arr = append(arr, d.instance(ti.typeid))
 		}
 		return arr
 	case s2pBitArr:
 		b.readBits8() // Field type (1)
 		length := int(readVarInt(b))
+		// Reject a length no input could back before make([]byte, (length+7)/8).
+		if length < 0 || length > b.bitsLeft() {
+			panic(errInvalidLength)
+		}
 		return BitArr{Count: length, Data: b.readAligned((length + 7) / 8)}
 	case s2pBlob:
 		b.readBits8() // Field type (2)
 		length := int(readVarInt(b))
+		if length < 0 || length > b.bytesLeft() {
+			panic(errInvalidLength)
+		}
 		return string(b.readAligned(length))
 	case s2pOptional:
 		b.readBits8() // Field type (4)
@@ -169,9 +180,17 @@ func skipInstance(b *bitPackedBuff) {
 			skipInstance(b)
 		}
 	case 1: // bit array
-		b.readAligned((int(readVarInt(b)) + 7) / 8)
+		bits := int(readVarInt(b))
+		if bits < 0 || bits > b.bitsLeft() {
+			panic(errInvalidLength)
+		}
+		b.readAligned((bits + 7) / 8)
 	case 2: // blob
-		b.readAligned(int(readVarInt(b)))
+		n := int(readVarInt(b))
+		if n < 0 || n > b.bytesLeft() {
+			panic(errInvalidLength)
+		}
+		b.readAligned(n)
 	case 3: // choice
 		readVarInt(b) // tag
 		skipInstance(b)

--- a/versioneddec.go
+++ b/versioneddec.go
@@ -52,6 +52,11 @@ func (d *versionedDec) instance(typeid int) interface{} {
 			s[name] = val
 		}
 		length := int(readVarInt(b))
+		// A negative field count is malformed: the loop below would read no fields
+		// and leave the encoded fields unconsumed, desyncing the rest of the stream.
+		if length < 0 {
+			panic(errInvalidLength)
+		}
 		// tag->index map is precomputed once per type at parse time (ti.tagIndex),
 		// so this struct decode does not rebuild it per instance.
 		tagIndex := ti.tagIndex
@@ -99,6 +104,9 @@ func (d *versionedDec) instance(typeid int) interface{} {
 		b.readBits8() // Field type (3)
 		tag := int(readVarInt(b))
 		if tag < 0 || tag >= len(ti.fields) {
+			// The choice's value still follows and is self-describing in the
+			// versioned format; skip it so the stream stays in sync.
+			skipInstance(b)
 			return nil
 		}
 		f := ti.fields[tag]
@@ -109,8 +117,10 @@ func (d *versionedDec) instance(typeid int) interface{} {
 	case s2pArr:
 		b.readBits8() // Field type (0)
 		length := readVarInt(b)
+		// A negative length is malformed; abort rather than returning nil and
+		// leaving the encoded elements unconsumed (consistent with blob/bitarray).
 		if length < 0 {
-			return nil
+			panic(errInvalidLength)
 		}
 		// Grow with append instead of make([]interface{}, length): the length is
 		// attacker-controlled and preallocating from it can OOM-kill the process
@@ -176,7 +186,11 @@ func skipInstance(b *bitPackedBuff) {
 	fieldType := b.readBits8()
 	switch fieldType {
 	case 0: // array
-		for i := readVarInt(b); i > 0; i-- {
+		n := readVarInt(b)
+		if n < 0 {
+			panic(errInvalidLength)
+		}
+		for ; n > 0; n-- {
 			skipInstance(b)
 		}
 	case 1: // bit array
@@ -199,7 +213,11 @@ func skipInstance(b *bitPackedBuff) {
 			skipInstance(b)
 		}
 	case 5: // struct
-		for i := readVarInt(b); i > 0; i-- {
+		n := readVarInt(b)
+		if n < 0 {
+			panic(errInvalidLength)
+		}
+		for ; n > 0; n-- {
 			readVarInt(b) // tag
 			skipInstance(b)
 		}


### PR DESCRIPTION
This pull request implements comprehensive fixes to the replay decoder to prevent out-of-memory (OOM) and panic vulnerabilities caused by attacker-controlled length fields. It also improves decoder correctness, performance, and test coverage. The most important changes are grouped below.

**Security and correctness fixes:**

* All array, bit array, and blob decoders now validate declared lengths against the remaining buffer before allocating memory, preventing OOM and panic exploits from crafted inputs. This includes both bit-packed and versioned decoders, as well as the `skipInstance` logic. [[1]](diffhunk://#diff-0b3abb3b4f02bebfac933df7a6d18419c4e834830443344c36b43e230ab22986L101-R124) [[2]](diffhunk://#diff-0b3abb3b4f02bebfac933df7a6d18419c4e834830443344c36b43e230ab22986R133-R136) [[3]](diffhunk://#diff-0b3abb3b4f02bebfac933df7a6d18419c4e834830443344c36b43e230ab22986L91-R94) [[4]](diffhunk://#diff-9b17c820aa6d625b470293805a7f3e96e287db8e5776c9dc0de49a5f1e5eebccL114-R136) [[5]](diffhunk://#diff-9b17c820aa6d625b470293805a7f3e96e287db8e5776c9dc0de49a5f1e5eebccL172-R193) [[6]](diffhunk://#diff-9b17c820aa6d625b470293805a7f3e96e287db8e5776c9dc0de49a5f1e5eebccL103-R101) [[7]](diffhunk://#diff-4bf33a613a19b43d13316ae881fa8ca1db2caa77e7eb61fc556e12520f22a394R9-R47)
* Fixed an off-by-one error in bit-packed choice decoding: tags equal to the number of fields are now correctly rejected, eliminating a possible panic.

**Performance improvements:**

* The tag-to-index map for struct decoding is now built once per type at parse time and reused, instead of being rebuilt for every decoded struct instance. This significantly reduces CPU usage during replay parsing. [[1]](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R65-R70) [[2]](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R146-R150) [[3]](diffhunk://#diff-9b17c820aa6d625b470293805a7f3e96e287db8e5776c9dc0de49a5f1e5eebccL55-R57)

**Decoder logic improvements:**

* The array decoders now grow slices with `append` rather than preallocating from untrusted lengths, so memory usage matches the actual data decoded and cannot be exploited for large allocations. [[1]](diffhunk://#diff-0b3abb3b4f02bebfac933df7a6d18419c4e834830443344c36b43e230ab22986L101-R124) [[2]](diffhunk://#diff-9b17c820aa6d625b470293805a7f3e96e287db8e5776c9dc0de49a5f1e5eebccL114-R136)
* The event delta decoder now decodes field values exactly once, preventing desynchronization of the input stream. Also, unknown fields are skipped correctly without misinterpreting tags as type IDs. [[1]](diffhunk://#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38L459-R465) [[2]](diffhunk://#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38L496-R504) [[3]](diffhunk://#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38L519-R527)

**Testing and dependencies:**

* Added regression tests in `audit_repro_test.go` to pin the fixed vulnerabilities and ensure they do not recur.
* Updated Go version and dependency on `mpq` to latest patch releases.